### PR TITLE
Fix employee route ordering

### DIFF
--- a/backend/routes/employee.js
+++ b/backend/routes/employee.js
@@ -6,9 +6,10 @@ const router = express.Router()
 
 router.get('/', authMiddleware, getEmployees)
 router.post('/add', authMiddleware, upload.single('image'), addEmployee)
+// Specific routes should be defined before the generic ':id' route
+router.get('/department/:id', authMiddleware, fetchEmployeesByDepId)
 router.get('/:id', authMiddleware, getEmployee)
 router.put('/:id', authMiddleware, updateEmployee)
-router.get('/department/:id', authMiddleware, fetchEmployeesByDepId)
 
 
 export default router


### PR DESCRIPTION
## Summary
- ensure Express routes match `/department/:id` before generic `/:id`

## Testing
- `npm test` in backend (fails: no test specified)
- `npm test` in frontend (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_685f1de16bc08321bbc2268fc5c93521